### PR TITLE
Changed getAllOptions() to allow "0"

### DIFF
--- a/lib/OptionParser.php
+++ b/lib/OptionParser.php
@@ -243,7 +243,7 @@ class OptionParser
       $options = array();
 
       foreach($this->_flags as $option => $index) {
-        if(!empty($this->_options[$index])) {
+        if(array_key_exists($index, $this->_options)) {
           $options[$option] = $this->_options[$index];
         }
       }


### PR DESCRIPTION
Let's say we want to parse an option with value "0":

``` php
    $parser->addRule('port::');
    $args = array('progname', '--port=0');
    $parser->parse($args);

    //when we try to get option, it returns correct value
    var_dump($parser->getOption('port')); //$args

    //when we try to get alloptions,
    //an option with value '0' is not included
    var_dump($parser->getAllOptions()); //array(0) {}
```

I think it is not correct behavior.

This pull-request fixes it.
